### PR TITLE
DS-203 - Fix race condition breaking replication.

### DIFF
--- a/libraries/provider_database_mysql_user.rb
+++ b/libraries/provider_database_mysql_user.rb
@@ -57,6 +57,7 @@ class Chef
                                   " '#{new_resource.password}'"
                                 end
                 end
+                repair_client.query("SET SESSION sql_log_bin = 0")
                 repair_client.query(repair_sql)
               ensure
                 close_repair_client
@@ -89,6 +90,7 @@ class Chef
               begin
                 repair_sql = 'DROP USER'
                 repair_sql += " '#{new_resource.username}'@'#{new_resource.host}'"
+                repair_client.query("SET SESSION sql_log_bin = 0")
                 repair_client.query repair_sql
               ensure
                 close_repair_client
@@ -149,6 +151,7 @@ class Chef
 
                 redacted_sql = redact_password(repair_sql, new_resource.password)
                 Chef::Log.debug("#{@new_resource}: granting with sql [#{redacted_sql}]")
+                repair_client.query("SET SESSION sql_log_bin = 0")
                 repair_client.query(repair_sql)
                 repair_client.query('FLUSH PRIVILEGES')
               ensure
@@ -195,6 +198,7 @@ class Chef
                 revoke_statement += " FROM `#{@new_resource.username}`@`#{@new_resource.host}` "
 
                 Chef::Log.debug("#{@new_resource}: revoking access with statement [#{revoke_statement}]")
+                repair_client.query("SET SESSION sql_log_bin = 0")
                 repair_client.query(revoke_statement)
                 repair_client.query('FLUSH PRIVILEGES')
                 @new_resource.updated_by_last_action(true)
@@ -361,6 +365,7 @@ class Chef
                                 "IDENTIFIED BY '#{new_resource.password}'"
                               end
               end
+              repair_client.query("SET SESSION sql_log_bin = 0")
               repair_client.query(repair_sql)
             ensure
               close_repair_client


### PR DESCRIPTION
In an environment that runs chef non-deterministically, the DDL to
maintain users may result in a breakage of replication. For example, if
a `CREATE USER` is run on a master database _after_ it is run on a
replica, the replica will encounter an error due to the user already
existing.

Further, we often want different roles present on different machines.
For example, we do not necessarily want `read-only` users present on the
master databases, nor do we want `read-write` users present on the
replicas (why tempt fate?).

This change is simple: for the current session, no statements should be
recorded in the binary logs.

N.B.: This doesn't work as expected for write-set replication used by
Galera. Specifically, when the statements are write-set replicated, they
are then recorded in the certifying nodes' binary logs, which then may
get replicated. As such, for Galera topologies, manual intervention is
required.